### PR TITLE
Detect if sessions are already temporalized

### DIFF
--- a/temporal_sqlalchemy/__init__.py
+++ b/temporal_sqlalchemy/__init__.py
@@ -6,6 +6,6 @@ from .bases import (
     EntityClock,
     TemporalProperty,
     TemporalActivityMixin)
-from .session import temporal_session, persist_history
+from .session import temporal_session, persist_history, is_temporal_session
 from .clock import add_clock, get_activity_clock_backref, get_history_model, get_history_model
 from .core import TemporalModel

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -1,4 +1,5 @@
 import datetime
+import functools
 import itertools
 import typing
 
@@ -25,15 +26,25 @@ def persist_history(session: orm.Session, flush_context, instances):
         obj.temporal_options.record_history(obj, session, correlate_timestamp)
 
 
+@functools.singledispatch
+def _flag_as_temporal(session_obj):
+    raise ValueError('Invalid session')
+
+
+@_flag_as_temporal.register(orm.Session)
+def _(session_obj):
+    session_obj.info[TEMPORAL_FLAG] = True
+
+
+@_flag_as_temporal.register(orm.sessionmaker)
+def _(session_obj):
+    session_obj.configure(info={TEMPORAL_FLAG: True})
+
+
 def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker]) -> orm.Session:
     if not is_temporal_session(session):
         event.listen(session, 'before_flush', persist_history)
-        if isinstance(session, orm.Session):
-            session.info[TEMPORAL_FLAG] = True
-        elif isinstance(session, orm.sessionmaker):
-            session.configure(info={TEMPORAL_FLAG: True})
-        else:
-            raise ValueError('Invalid session')
+        _flag_as_temporal(session)
 
     return session
 

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -7,6 +7,8 @@ import sqlalchemy.orm as orm
 
 from temporal_sqlalchemy.bases import ClockedOption, Clocked
 
+TEMPORAL_FLAG = '__temporal'
+
 
 def _temporal_models(session: orm.Session) -> typing.Iterable[Clocked]:
     for obj in session:
@@ -23,6 +25,18 @@ def persist_history(session: orm.Session, flush_context, instances):
         obj.temporal_options.record_history(obj, session, correlate_timestamp)
 
 
-def temporal_session(session: orm.Session) -> orm.Session:
-    event.listen(session, 'before_flush', persist_history)
+def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker]) -> orm.Session:
+    if not is_temporal_session(session):
+        event.listen(session, 'before_flush', persist_history)
+        if isinstance(session, orm.Session):
+            session.info[TEMPORAL_FLAG] = True
+        elif isinstance(session, orm.sessionmaker):
+            session.configure(info={TEMPORAL_FLAG: True})
+        else:
+            raise ValueError('Invalid session')
+
     return session
+
+
+def is_temporal_session(session: orm.Session) -> bool:
+    return isinstance(session, orm.Session) and session.info.get(TEMPORAL_FLAG)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,8 +1,10 @@
 import datetime
 
 import pytest
+import sqlalchemy.orm as orm
 
 from . import shared, models
+from temporal_sqlalchemy import is_temporal_session, temporal_session
 
 
 class TestSession(shared.DatabaseTest):
@@ -16,6 +18,24 @@ class TestSession(shared.DatabaseTest):
             datetime_prop=datetime.datetime.now(datetime.timezone.utc)
         )
 
+    @pytest.fixture()
+    def raw_session_maker(self):
+        session = orm.sessionmaker()
+
+        yield session
+
+        session.close_all()
+
+    @pytest.fixture()
+    def raw_session(self, connection, raw_session_maker):
+        transaction = connection.begin()
+        sess = raw_session_maker(bind=connection)
+
+        yield sess
+
+        transaction.rollback()
+        sess.close()
+
     def test_errors_on_delete(self, session, newstylemodel):
         session.add(newstylemodel)
         session.commit()
@@ -23,3 +43,14 @@ class TestSession(shared.DatabaseTest):
         with pytest.raises(ValueError):
             session.delete(newstylemodel)
             session.commit()
+
+    def test_is_temporal_session(self, session, raw_session):
+        # verify temporal session
+        assert is_temporal_session(session)
+
+        # verify double-wrapped session
+        double_wrapped_session = temporal_session(session)
+        assert is_temporal_session(double_wrapped_session)
+
+        # verify plain session
+        assert not is_temporal_session(raw_session)


### PR DESCRIPTION
* Added `is_temporal_session()` to check if a session is already temporalized
* Modified `temporal_session()` to avoid re-registering the `'before_flush'` handler

Without this, any session that are double-wrapped with `temporal_session()` will cause the `persist_history` to be executed more than once.  This leads to failed operations because the clock tables exclusion constraints prevent double-writes (materializes as `sqlalchemy.exc.IntegrityError` exception).

This fix leverages the SQLAlchemy [Session.info()](http://docs.sqlalchemy.org/en/latest/orm/session_api.html#sqlalchemy.orm.session.Session.info) to allow custom defined properties on session instances.