### PR TITLE
Add check constraint on history tables to prevent empty vclock

### DIFF
--- a/temporal_sqlalchemy/clock.py
+++ b/temporal_sqlalchemy/clock.py
@@ -301,6 +301,10 @@ def build_history_table(
             *itertools.chain(entity_constraints, [('effective', '&&')]),
             name=truncate_identifier('%s_excl_effective' % table_name)
         ),
+        sa.CheckConstraint(
+            'LOWER(vclock) IS NOT NULL',
+            name='%s_check_vclock_lower_bounded' % table_name
+        )
     ]
 
     return sa.Table(


### PR DESCRIPTION
Fixes for issue #21 

* Adds check constraint (via SQLAlchemy core [CheckConstraint](http://docs.sqlalchemy.org/en/rel_1_1/core/constraints.html#check-constraint)) to fail immediately with an `IntegrityError` should a `flush()` call inject an invalid `vclock` value.
* Added regression tests to ensure `IntegrityError` is thrown for both direct updates and incorrect usage of `flush()`.

NOTE: Existing temporal models will still require a migration