### PR TITLE
Raise an assertion if a flush() occurs on changes without a proper clock tick

### DIFF
--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -4,6 +4,7 @@ Here is an entirely incomplete list of amazing contributors.
 
     Alec Clowes <alec.clowes@cloverhealth.com>
     Ben Kudria <ben.kudria@cloverhealth.com>
+    Bijan Vakili <bijan.vakili@cloverhealth.com>
     Dave Flerlage <dave.flerlage@cloverhealth.com>
     Diego Argueta <diego.argueta@cloverhealth.com>
     George Leslie-Waksman <george@cloverhealth.com>

--- a/temporal_sqlalchemy/metadata.py
+++ b/temporal_sqlalchemy/metadata.py
@@ -1,0 +1,24 @@
+import sqlalchemy.orm as orm
+
+TEMPORAL_METADATA_KEY = '__temporal'
+
+__all__ = [
+    'get_session_metadata',
+    'set_session_metadata',
+]
+
+
+def set_session_metadata(session: orm.Session, metadata: dict):
+    if isinstance(session, orm.Session):
+        session.info[TEMPORAL_METADATA_KEY] = metadata
+    elif isinstance(session, orm.sessionmaker):
+        session.configure(info={TEMPORAL_METADATA_KEY: metadata})
+    else:
+        raise ValueError('Invalid session')
+
+
+def get_session_metadata(session: orm.Session) -> dict:
+    """
+    :return: metadata dictionary, or None if it was never installed
+    """
+    return session.info.get(TEMPORAL_METADATA_KEY)

--- a/temporal_sqlalchemy/version.py
+++ b/temporal_sqlalchemy/version.py
@@ -1,2 +1,2 @@
 """Version information."""
-__version__ = '0.3.1'
+__version__ = '0.3.2'

--- a/tests/test_temporal_models.py
+++ b/tests/test_temporal_models.py
@@ -323,6 +323,28 @@ class TestTemporalModels(shared.DatabaseTest):
                 str(excinfo)
             )
 
+
+    @pytest.mark.parametrize('session_func_name', (
+        'flush',
+        'commit'
+    ))
+    def test_allow_flushes_within_clock_ticks_when_strict_but_no_change(self, session, session_func_name):
+        session = temporal.temporal_session(session, strict_mode=True)
+
+        t = models.SimpleTableTemporal(
+            prop_a=1,
+            prop_b='foo',
+            prop_c=datetime.datetime(2016, 5, 11,
+                                     tzinfo=datetime.timezone.utc))
+        session.add(t)
+        session.commit()
+
+        with t.clock_tick():
+            t.prop_a = 1
+
+        eval('session.{func_name}()'.format(func_name=session_func_name))
+
+
     @pytest.mark.parametrize('session_func_name', (
             'flush',
             'commit'


### PR DESCRIPTION
Fix for issue #21 

* Added a `strict_mode` boolean flag to to throw an assertion exception if an `flush()` was triggered without a completed/changed clock tick.
    * This is **disabled** by default
    * If enabled, it will throw an `AssertionError` on invalid `Session.flush()` calls (and thus prevent empty `vclock` values in history )tables.