### PR TITLE
Issue #26: Remove compound primary keys on temporal clock tables

### DIFF
--- a/temporal_sqlalchemy/bases.py
+++ b/temporal_sqlalchemy/bases.py
@@ -3,9 +3,11 @@ import collections
 import contextlib
 import datetime as dt
 import typing
+import uuid
 import warnings
 
 import sqlalchemy as sa
+import sqlalchemy.dialects.postgresql as sap
 import sqlalchemy.orm as orm
 import sqlalchemy.orm.attributes as attributes
 import psycopg2.extras as psql_extras
@@ -21,9 +23,9 @@ T_PROPS = typing.TypeVar(
 
 
 class EntityClock(object):
-    tick = sa.Column(sa.Integer, primary_key=True, autoincrement=False)
-    timestamp = sa.Column(sa.DateTime(True),
-                          server_default=sa.func.current_timestamp())
+    id = sa.Column(sap.UUID(as_uuid=True), default=uuid.uuid4, primary_key=True)
+    tick = sa.Column(sa.Integer, nullable=False)
+    timestamp = sa.Column(sa.DateTime(True), server_default=sa.func.current_timestamp())
 
 
 class TemporalProperty(object):

--- a/temporal_sqlalchemy/version.py
+++ b/temporal_sqlalchemy/version.py
@@ -1,2 +1,2 @@
 """Version information."""
-__version__ = '0.3.2'
+__version__ = '0.3.3'

--- a/tests/test_temporal_model_mixin.py
+++ b/tests/test_temporal_model_mixin.py
@@ -2,6 +2,7 @@ import datetime
 
 import pytest
 import sqlalchemy as sa
+import sqlalchemy.exc as sa_exc
 import temporal_sqlalchemy as temporal
 
 from . import shared, models
@@ -37,7 +38,7 @@ def test_create_temporal_options():
             schema='bare_table_test_schema'
         ),
         'bare_table_single_pk_no_activity_clock',
-        {'tick', 'timestamp', 'entity_id'},
+        {'id', 'tick', 'timestamp', 'entity_id'},
         None
     ),
     (
@@ -50,7 +51,7 @@ def test_create_temporal_options():
             schema='bare_table_test_schema'
         ),
         'bare_table_compositve_pk_no_activity_clock',
-        {'tick', 'timestamp', 'entity_num_id', 'entity_text_id'},
+        {'id', 'tick', 'timestamp', 'entity_num_id', 'entity_text_id'},
         None
     ),
     (
@@ -62,7 +63,7 @@ def test_create_temporal_options():
             schema='bare_table_test_schema'
         ),
         'bare_table_single_pk_with_activity_clock',
-        {'tick', 'timestamp', 'entity_id', 'activity_id'},
+        {'id', 'tick', 'timestamp', 'entity_id', 'activity_id'},
         models.Activity
     ),
     (
@@ -75,7 +76,7 @@ def test_create_temporal_options():
             schema='bare_table_test_schema'
         ),
         'bare_table_compositve_pk_with_activity_clock',
-        {'tick', 'timestamp', 'entity_num_id', 'entity_text_id', 'activity_id'},
+        {'id', 'tick', 'timestamp', 'entity_num_id', 'entity_text_id', 'activity_id'},
         models.Activity
     )
 ))
@@ -189,7 +190,7 @@ class TestTemporalModelMixin(shared.DatabaseTest):
         session.add(newstylemodel)
         session.commit()
 
-        tick = session.query(clock_model).get((1, newstylemodel.id))
+        tick = session.query(clock_model).filter_by(tick=1, entity_id=newstylemodel.id).one()
         assert newstylemodel.vclock == 1
         assert newstylemodel.clock.count() == 1
         assert newstylemodel.date_created == tick.timestamp
@@ -199,7 +200,7 @@ class TestTemporalModelMixin(shared.DatabaseTest):
         session.add(newstylemodel)
         session.commit()
 
-        first_tick = session.query(clock_model).get((1, newstylemodel.id))
+        first_tick = session.query(clock_model).filter_by(tick=1, entity_id=newstylemodel.id).one()
         assert newstylemodel.vclock == 1
         assert newstylemodel.clock.count() == 1
         assert newstylemodel.date_created == first_tick.timestamp
@@ -210,7 +211,7 @@ class TestTemporalModelMixin(shared.DatabaseTest):
 
         session.commit()
 
-        second_tick = session.query(clock_model).get((1, newstylemodel.id))
+        second_tick = session.query(clock_model).filter_by(tick=1, entity_id=newstylemodel.id).one()
         assert newstylemodel.vclock == 2
         assert newstylemodel.clock.count() == 2
         assert newstylemodel.date_created == first_tick.timestamp
@@ -257,3 +258,19 @@ class TestTemporalModelMixin(shared.DatabaseTest):
                 session.query(history_model)
                 .order_by(history_model.vclock.desc()).first())
             assert clock.tick in history.vclock
+
+    def test_disallaw_same_tick_for_same_entity(self, session, newstylemodel):
+        clock_model = models.NewStyleModel.temporal_options.clock_model
+
+        session.add(newstylemodel)
+        session.commit()
+
+        first_tick = session.query(clock_model).first()
+        duplicate_tick = clock_model(
+            tick=first_tick.tick,
+            entity_id=first_tick.entity_id,
+            activity=models.Activity(description="Inserting a duplicate"),
+        )
+        session.add(duplicate_tick)
+        with pytest.raises(sa_exc.IntegrityError):
+            session.commit()


### PR DESCRIPTION
* Issue #26 : Replace compound primary key `(tick, entity_id)` on temporal clock tables with
    * Primary key `id` as `UUID` column
    * Unique constraint on `(tick, entity_id)`
* Bump version to 0.3.3