### PR TITLE
Deprecate clock_tick context manager

### DIFF
--- a/temporal_sqlalchemy/clock.py
+++ b/temporal_sqlalchemy/clock.py
@@ -12,6 +12,8 @@ import sqlalchemy.orm as orm
 from temporal_sqlalchemy import nine, util
 from temporal_sqlalchemy.bases import (
     T_PROPS,
+    ClockState,
+    ActivityState,
     Clocked,
     TemporalOption,
     TemporalActivityMixin,
@@ -94,8 +96,7 @@ def temporal_map(*track, mapper: orm.Mapper, activity_class=None, schema=None):
         clock_model=clock_model,
         activity_cls=activity_class
     )
-
-    event.listen(cls, 'init', init_clock)
+    cls.temporal_options.bind(cls)
 
 
 def init_clock(obj: Clocked, args, kwargs):

--- a/tests/test_temporal_model_mixin.py
+++ b/tests/test_temporal_model_mixin.py
@@ -154,11 +154,11 @@ class TestTemporalModelMixin(shared.DatabaseTest):
         session.commit()
 
         activity = models.Activity(description="Activity Description #2")
-        with newstylemodel.clock_tick(activity=activity):
-            newstylemodel.description = "this is new"
-            newstylemodel.int_prop = 2
-            newstylemodel.bool_prop = False
-            newstylemodel.datetime_prop = datetime.datetime(2017, 2, 10)
+        newstylemodel.activity = activity
+        newstylemodel.description = "this is new"
+        newstylemodel.int_prop = 2
+        newstylemodel.bool_prop = False
+        newstylemodel.datetime_prop = datetime.datetime(2017, 2, 10)
 
         session.commit()
 


### PR DESCRIPTION
- [ ] backwards compatible deprecation of `clock_tick` context manager
- [ ] ensure activity set when changing temporal properties and model clocked with `activity_cls`
- [ ] session and mapper event life cycle tests