### PR TITLE
Fix README formatting and bumpversion usage

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.3
+current_version = 0.4.4
 commit = True
 tag = True
 tag_name = {new_version}

--- a/README.rst
+++ b/README.rst
@@ -83,13 +83,13 @@ version is 1.2.3; you'll run one of the following:
 
 .. code-block:: sh
     # Change the version to 1.2.4
-    bumpversion --current-version 1.2.3 patch
+    bumpversion patch
 
     # Change the version to 1.3.0
-    bumpversion --current-version 1.2.3 minor
+    bumpversion minor
 
     # Change the version to 2.0.0
-    bumpversion --current-version 1.2.3 major
+    bumpversion major
 
 More information on ``bumpversion`` and its usage can be found
 `here <https://pypi.python.org/pypi/bumpversion>`_.

--- a/README.rst
+++ b/README.rst
@@ -1,8 +1,8 @@
 Temporal SQLAlchemy
--------------------
+===================
 
 Some Terms
-==========
+----------
 
 Temporal
   time dimension. A property can have spatial and/or temporal dimensions,
@@ -26,7 +26,7 @@ High Velocity
   state changes frequently or you need to walk the history regularly.
 
 Methodologies
-=============
+-------------
 
 There exist several ways to add a temporal dimension to your data.
 `SQLAlchemy Continuum`_ uses a shadow or history table for each versioned
@@ -78,10 +78,14 @@ Updating Version Numbers
 ~~~~~~~~~~~~~~~~~~~~~~~~
 
 Once development is done, as your *last commit* on the branch you'll want to
-change the version number and create a tag for deployment. Suppose the current
-version is 1.2.3; you'll run one of the following:
+change the version number and create a tag for deployment. Please do this via
+the ``bumpversion`` command. More information on ``bumpversion`` and its usage
+can be found `here <https://pypi.python.org/pypi/bumpversion>`_, but in most
+cases you'll run one of the following commands. Assuming the current version is
+1.2.3:
 
 .. code-block:: sh
+
     # Change the version to 1.2.4
     bumpversion patch
 
@@ -90,6 +94,3 @@ version is 1.2.3; you'll run one of the following:
 
     # Change the version to 2.0.0
     bumpversion major
-
-More information on ``bumpversion`` and its usage can be found
-`here <https://pypi.python.org/pypi/bumpversion>`_.

--- a/setup.py
+++ b/setup.py
@@ -29,7 +29,7 @@ CLASSIFIERS = [
 
 setuptools.setup(
     name='temporal-sqlalchemy',
-    version='0.4.3',
+    version='0.4.4',
     description='Temporal Extensions for SQLAlchemy ORM',
     long_description='file: README.rst',
     author='Clover Health Engineering',

--- a/temporal_sqlalchemy/version.py
+++ b/temporal_sqlalchemy/version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
-__version__ = '0.4.3'
+__version__ = '0.4.4'
 __version_info__ = __version__.split('.')


### PR DESCRIPTION
The README is rendering as plain text because the ReST formatting is wrong. This fixes that and also rewords some of the `bumpversion` instructions.