### PR TITLE
[BUG] Fix broken 3.3 support

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.4
+current_version = 0.4.5
 commit = True
 tag = True
 tag_name = {new_version}

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
         - '3.6'
         - '3.5'
         - '3.4'
+        - '3.3'
       addons:
         postgresql: 9.5
       env: PG=9.5
@@ -19,6 +20,7 @@ matrix:
         - '3.6'
         - '3.5'
         - '3.4'
+        - '3.3'
       addons:
         postgresql: 9.4
       env: PG=9.4
@@ -26,6 +28,7 @@ matrix:
         - '3.6'
         - '3.5'
         - '3.4'
+        - '3.3'
       addons:
         postgresql: 9.3
       env: PG=9.3

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,6 +1,6 @@
 Thanks for downloading temporal-sqlalchemy.
 
-To install it, make sure you have Python 3.4 or greater installed. Then run
+To install it, make sure you have Python 3.3 or greater installed. Then run
 this command from the command prompt:
 
     python3 setup.py install

--- a/README.rst
+++ b/README.rst
@@ -57,11 +57,12 @@ this repo run:
 
     # Install all the Python versions this package supports. This will take some
     # time.
+    pyenv install 3.3.6
     pyenv install 3.4.6
     pyenv install 3.5.3
     pyenv install 3.6.3
 
-    pyenv local 3.6.3 3.5.3 3.4.6
+    pyenv local 3.6.3 3.5.3 3.4.6 3.3.6
 
     # Install the development dependencies
     pip3 install -Ur dev-requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   override:
     - pip3 install -q -r dev-requirements.txt
-    - pyenv local 3.6.2 3.5.3 3.4.4
+    - pyenv local 3.6.2 3.5.3 3.4.4 3.3.6
 
 test:
   override:

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ CLASSIFIERS = [
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3 :: Only',
+    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
@@ -40,9 +41,10 @@ setuptools.setup(
     platforms=['any'],
     keywords='sqlalchemy postgresql orm temporal',
     classifiers=CLASSIFIERS,
-    python_requires='>=3.4',
+    python_requires='>=3.3',
     install_requires=[
         'psycopg2>=2.6.2',
+        'singledispatch>=3.4.0.0;python_version<"3.4"',
         'sqlalchemy>=1.0.15',
         'typing>=3.5.2,<4.0.0;python_version<"3.5"'
     ],

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ CLASSIFIERS = [
 
 setuptools.setup(
     name='temporal-sqlalchemy',
-    version='0.4.4',
+    version='0.4.5',
     description='Temporal Extensions for SQLAlchemy ORM',
     long_description='file: README.rst',
     author='Clover Health Engineering',

--- a/temporal_sqlalchemy/version.py
+++ b/temporal_sqlalchemy/version.py
@@ -1,4 +1,4 @@
 """Version information."""
 
-__version__ = '0.4.4'
+__version__ = '0.4.5'
 __version_info__ = __version__.split('.')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py34,py35,py36
+envlist = py33,py34,py35,py36
 usedevelop = true
 passenv = *
 


### PR DESCRIPTION
Python 3.3 support was broken because `singledispatch` wasn't being installed as a dependency but it was used in `nine.py`. This was entirely my fault in #40 (`setup.py` line 20). Somehow I overlooked it.

Sorry!