### PR TITLE
Batch history building during commit instead of flush

### DIFF
--- a/temporal_sqlalchemy/bases.py
+++ b/temporal_sqlalchemy/bases.py
@@ -49,12 +49,15 @@ class TemporalOption(object):
             history_models: typing.Dict[T_PROPS, nine.Type[TemporalProperty]],
             temporal_props: typing.Iterable[T_PROPS],
             clock_model: nine.Type[EntityClock],
-            activity_cls: nine.Type[TemporalActivityMixin] = None):
+            activity_cls: nine.Type[TemporalActivityMixin] = None,
+            allow_persist_on_commit: bool = False):
         self.history_models = history_models
         self.temporal_props = temporal_props
 
         self.clock_model = clock_model
         self.activity_cls = activity_cls
+
+        self.allow_persist_on_commit = allow_persist_on_commit
 
     @property
     def clock_table(self):

--- a/temporal_sqlalchemy/bases.py
+++ b/temporal_sqlalchemy/bases.py
@@ -155,13 +155,18 @@ class TemporalOption(object):
     def get_history(self, clocked: 'Clocked'):
         history = {}
 
+        new_tick = self._get_new_tick(clocked)
+
+        vclock_history = attributes.get_history(clocked, 'vclock')
+        is_vclock_unchanged = vclock_history.unchanged and new_tick == vclock_history.unchanged[0]
+
         for prop, cls in self.history_models.items():
             value = self._get_prop_value(clocked, prop)
 
             if value is not NOT_FOUND_SENTINEL:
                 history[prop] = value
 
-        return history
+        return history, is_vclock_unchanged
 
     def _cap_previous_history_row(self, clocked, new_clock, cls):
         # Cap previous history row if exists

--- a/temporal_sqlalchemy/bases.py
+++ b/temporal_sqlalchemy/bases.py
@@ -20,6 +20,8 @@ _ClockSet = collections.namedtuple('_ClockSet', ('effective', 'vclock'))
 T_PROPS = typing.TypeVar(
     'T_PROP', orm.RelationshipProperty, orm.ColumnProperty)
 
+NOT_FOUND_SENTINEL = object()
+
 
 class EntityClock(object):
     id = sa.Column(sap.UUID(as_uuid=True), default=uuid.uuid4, primary_key=True)
@@ -92,66 +94,28 @@ class TemporalOption(object):
                        session: orm.Session,
                        timestamp: dt.datetime):
         """record all history for a given clocked object"""
-        state = attributes.instance_state(clocked)
-        vclock_history = attributes.get_history(clocked, 'vclock')
-        try:
-            new_tick = state.dict['vclock']
-        except KeyError:
-            # TODO understand why this is necessary
-            new_tick = getattr(clocked, 'vclock')
+        new_tick = self._get_new_tick(clocked)
 
         is_strict_mode = get_session_metadata(session).get('strict_mode', False)
+        vclock_history = attributes.get_history(clocked, 'vclock')
         is_vclock_unchanged = vclock_history.unchanged and new_tick == vclock_history.unchanged[0]
 
         new_clock = self.make_clock(timestamp, new_tick)
         attr = {'entity': clocked}
 
         for prop, cls in self.history_models.items():
-            hist = attr.copy()
-            # fires a load on any deferred columns
-            if prop.key not in state.dict:
-                getattr(clocked, prop.key)
+            value = self._get_prop_value(clocked, prop)
 
-            if isinstance(prop, orm.RelationshipProperty):
-                changes = attributes.get_history(
-                    clocked, prop.key,
-                    passive=attributes.PASSIVE_NO_INITIALIZE)
-            else:
-                changes = attributes.get_history(clocked, prop.key)
-
-            if changes.added:
+            if value is not NOT_FOUND_SENTINEL:
                 if is_strict_mode:
                     assert not is_vclock_unchanged, \
                         'flush() has triggered for a changed temporalized property outside of a clock tick'
 
-                # Cap previous history row if exists
-                if sa.inspect(clocked).identity is not None:
-                    # but only if it already exists!!
-                    effective_close = sa.func.tstzrange(
-                        sa.func.lower(cls.effective),
-                        new_clock.effective.lower,
-                        '[)')
-                    vclock_close = sa.func.int4range(
-                        sa.func.lower(cls.vclock),
-                        new_clock.vclock.lower,
-                        '[)')
-
-                    history_query = getattr(
-                        clocked, cls.entity.property.backref[0])
-                    history_query.filter(
-                        sa.and_(
-                            sa.func.upper_inf(cls.effective),
-                            sa.func.upper_inf(cls.vclock),
-                        )
-                    ).update(
-                        {
-                            cls.effective: effective_close,
-                            cls.vclock: vclock_close,
-                        }, synchronize_session=False
-                    )
+                self._cap_previous_history_row(clocked, new_clock, cls)
 
                 # Add new history row
-                hist[prop.key] = changes.added[0]
+                hist = attr.copy()
+                hist[prop.key] = value
                 session.add(
                     cls(
                         vclock=new_clock.vclock,
@@ -159,6 +123,101 @@ class TemporalOption(object):
                         **hist
                     )
                 )
+
+    def record_history_on_commit(self,
+                       clocked: 'Clocked',
+                       changes: dict,
+                       session: orm.Session,
+                       timestamp: dt.datetime):
+        """record all history for a given clocked object"""
+        new_tick = self._get_new_tick(clocked)
+
+        new_clock = self.make_clock(timestamp, new_tick)
+        attr = {'entity': clocked}
+
+        for prop, cls in self.history_models.items():
+            if prop in changes:
+                value = changes[prop]
+
+                self._cap_previous_history_row(clocked, new_clock, cls)
+
+                # Add new history row
+                hist = attr.copy()
+                hist[prop.key] = value
+                session.add(
+                    cls(
+                        vclock=new_clock.vclock,
+                        effective=new_clock.effective,
+                        **hist
+                    )
+                )
+
+    def get_history(self, clocked: 'Clocked'):
+        history = {}
+
+        for prop, cls in self.history_models.items():
+            value = self._get_prop_value(clocked, prop)
+
+            if value is not NOT_FOUND_SENTINEL:
+                history[prop] = value
+
+        return history
+
+    def _cap_previous_history_row(self, clocked, new_clock, cls):
+        # Cap previous history row if exists
+        if sa.inspect(clocked).identity is not None:
+            # but only if it already exists!!
+            effective_close = sa.func.tstzrange(
+                sa.func.lower(cls.effective),
+                new_clock.effective.lower,
+                '[)')
+            vclock_close = sa.func.int4range(
+                sa.func.lower(cls.vclock),
+                new_clock.vclock.lower,
+                '[)')
+
+            history_query = getattr(
+                clocked, cls.entity.property.backref[0])
+            history_query.filter(
+                sa.and_(
+                    sa.func.upper_inf(cls.effective),
+                    sa.func.upper_inf(cls.vclock),
+                )
+            ).update(
+                {
+                    cls.effective: effective_close,
+                    cls.vclock: vclock_close,
+                }, synchronize_session=False
+            )
+
+    def _get_prop_value(self, clocked, prop):
+        state = attributes.instance_state(clocked)
+
+        # fires a load on any deferred columns
+        if prop.key not in state.dict:
+            getattr(clocked, prop.key)
+
+        if isinstance(prop, orm.RelationshipProperty):
+            changes = attributes.get_history(
+                clocked, prop.key,
+                passive=attributes.PASSIVE_NO_INITIALIZE)
+        else:
+            changes = attributes.get_history(clocked, prop.key)
+
+        if changes.added:
+            return changes.added[0]
+
+        return NOT_FOUND_SENTINEL
+
+    def _get_new_tick(self, clocked):
+        state = attributes.instance_state(clocked)
+        try:
+            new_tick = state.dict['vclock']
+        except KeyError:
+            # TODO understand why this is necessary
+            new_tick = getattr(clocked, 'vclock')
+
+        return new_tick
 
 
 class Clocked(object):

--- a/temporal_sqlalchemy/clock.py
+++ b/temporal_sqlalchemy/clock.py
@@ -19,7 +19,8 @@ from temporal_sqlalchemy.bases import (
     TemporalProperty)
 
 
-def temporal_map(*track, mapper: orm.Mapper, activity_class=None, schema=None):
+def temporal_map(*track, mapper: orm.Mapper, activity_class=None,
+                 schema=None, allow_persist_on_commit=False):
     assert 'vclock' not in track
 
     cls = mapper.class_
@@ -92,7 +93,8 @@ def temporal_map(*track, mapper: orm.Mapper, activity_class=None, schema=None):
         temporal_props=tracked_props,
         history_models=history_models,
         clock_model=clock_model,
-        activity_cls=activity_class
+        activity_cls=activity_class,
+        allow_persist_on_commit=allow_persist_on_commit,
     )
 
     event.listen(cls, 'init', init_clock)
@@ -153,7 +155,8 @@ def defaults_safety(*track, mapper):
 # TODO kwargs to override default clock table and history tables prefix
 def add_clock(*props: typing.Iterable[str],  # noqa: C901
               activity_cls: nine.Type[TemporalActivityMixin] = None,
-              temporal_schema: typing.Optional[str] = None):
+              temporal_schema: typing.Optional[str] = None,
+              allow_persist_on_commit: bool = False):
     """Decorator to add clock and history to an orm model."""
 
     def make_temporal(cls: nine.Type[Clocked]):
@@ -163,7 +166,8 @@ def add_clock(*props: typing.Iterable[str],  # noqa: C901
         temporal_map(*props,
                      mapper=mapper,
                      activity_class=activity_cls,
-                     schema=temporal_schema)
+                     schema=temporal_schema,
+                     allow_persist_on_commit=allow_persist_on_commit)
         return cls
 
     return make_temporal

--- a/temporal_sqlalchemy/metadata.py
+++ b/temporal_sqlalchemy/metadata.py
@@ -21,4 +21,9 @@ def get_session_metadata(session: orm.Session) -> dict:
     """
     :return: metadata dictionary, or None if it was never installed
     """
-    return session.info.get(TEMPORAL_METADATA_KEY)
+    if isinstance(session, orm.Session):
+        return session.info.get(TEMPORAL_METADATA_KEY)
+    elif isinstance(session, orm.sessionmaker):
+        return session.kw.get('info', {}).get(TEMPORAL_METADATA_KEY)
+    else:
+        raise ValueError('Invalid session')

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -84,7 +84,6 @@ def persist_history(session: orm.Session, flush_context, instances):
 def enable_is_committing_flag(session):
     metadata = get_session_metadata(session)
     persist_on_commit = metadata[PERSIST_ON_COMMIT_KEY]
-
     if not persist_on_commit:
         return
 

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -27,7 +27,57 @@ def persist_history(session: orm.Session, flush_context, instances):
         obj.temporal_options.record_history(obj, session, correlate_timestamp)
 
 
-def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker], strict_mode=False) -> orm.Session:
+def persist_history_on_commit(session: orm.Session, flush_context, instances):
+    if any(_temporal_models(session.deleted)):
+        raise ValueError("Cannot delete temporal objects.")
+
+    metadata = get_session_metadata(session)
+
+    for obj in _temporal_models(itertools.chain(session.dirty, session.new)):
+        metadata['changeset'].add(obj)
+
+    if metadata['is_committing']:
+        correlate_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
+
+        for obj in metadata['changeset']:
+            obj.temporal_options.record_history(obj, session, correlate_timestamp)
+
+        metadata['changeset'].clear()
+
+
+def enable_is_committing_flag(session):
+    metadata = get_session_metadata(session)
+    metadata['is_committing'] = True
+
+
+def disable_is_committing_flag(session):
+    metadata = get_session_metadata(session)
+    metadata['is_committing'] = False
+
+
+PERSIST_ON_COMMIT_LISTENERS = (
+    ('before_flush', persist_history_on_commit),
+    ('before_commit', enable_is_committing_flag),
+    ('after_commit', disable_is_committing_flag),
+)
+
+
+PERSIST_LISTENERS = (
+    ('before_flush', persist_history),
+)
+
+
+def set_listeners(session, to_enable=(), to_disable=()):
+    for listener_args in to_disable:
+        if event.contains(session, *listener_args):
+            event.remove(session, *listener_args)
+
+    for listener_args in to_enable:
+        event.listen(session, *listener_args)
+
+
+def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker],
+    strict_mode=False, persist_on_commit=False) -> orm.Session:
     """
     Setup the session to track changes via temporal
 
@@ -36,17 +86,36 @@ def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker], stric
     :return: temporalized SQLALchemy ORM session
     """
     temporal_metadata = {
-        'strict_mode': strict_mode
+        'strict_mode': strict_mode,
     }
+    if persist_on_commit:
+        temporal_metadata.update({
+            'persist_on_commit': persist_on_commit,
+            'changeset': set(),
+            'is_committing': False,
+        })
 
     # defer listening to the flush hook until after we update the metadata
-    install_flush_hook = not is_temporal_session(session)
+    old_metadata = get_session_metadata(session) or {}
+    install_flush_hook = not is_temporal_session(session) \
+        or persist_on_commit != old_metadata.get('persist_on_commit', False)
 
     # update to the latest metadata
     set_session_metadata(session, temporal_metadata)
 
     if install_flush_hook:
-        event.listen(session, 'before_flush', persist_history)
+        if persist_on_commit:
+            set_listeners(
+                session,
+                to_enable=PERSIST_ON_COMMIT_LISTENERS,
+                to_disable=PERSIST_LISTENERS,
+            )
+        else:
+            set_listeners(
+                session,
+                to_enable=PERSIST_LISTENERS,
+                to_disable=PERSIST_ON_COMMIT_LISTENERS,
+            )
 
     return session
 

--- a/tests/models.py
+++ b/tests/models.py
@@ -244,3 +244,30 @@ class NewStyleModelWithRelationship(Base, temporal_sqlalchemy.TemporalModel):
             'rel',
         )
         schema = TEMPORAL_SCHEMA
+
+
+class PersistenceStrategy(temporal_sqlalchemy.Clocked, Base):
+    __abstract__ = True
+
+    id = auto_uuid()
+    prop_a = sa.Column(sa.Integer)
+    prop_b = sa.Column(sap.TEXT)
+
+
+@temporal_sqlalchemy.add_clock(
+    'prop_a', 'prop_b',
+    temporal_schema=TEMPORAL_SCHEMA,
+    activity_cls=Activity)
+class PersistOnFlushTable(PersistenceStrategy):
+    __tablename__ = 'persist_on_flush_table'
+    __table_args__ = {'schema': SCHEMA}
+
+
+@temporal_sqlalchemy.add_clock(
+    'prop_a', 'prop_b',
+    temporal_schema=TEMPORAL_SCHEMA,
+    activity_cls=Activity,
+    allow_persist_on_commit=True)
+class PersistOnCommitTable(PersistenceStrategy):
+    __tablename__ = 'persist_on_commit_table'
+    __table_args__ = {'schema': SCHEMA}

--- a/tests/models.py
+++ b/tests/models.py
@@ -252,10 +252,14 @@ class PersistenceStrategy(temporal_sqlalchemy.Clocked, Base):
     id = auto_uuid()
     prop_a = sa.Column(sa.Integer)
     prop_b = sa.Column(sap.TEXT)
+    prop_c = sa.Column(sa.DateTime(True))
+    prop_d = sa.Column(mutable.MutableDict.as_mutable(sap.JSON))
+    prop_e = sa.Column(sap.DATERANGE)
+    prop_f = sa.Column(sap.ARRAY(sap.TEXT))
 
 
 @temporal_sqlalchemy.add_clock(
-    'prop_a', 'prop_b',
+    'prop_a', 'prop_b', 'prop_c', 'prop_d', 'prop_e', 'prop_f',
     temporal_schema=TEMPORAL_SCHEMA,
     activity_cls=Activity)
 class PersistOnFlushTable(PersistenceStrategy):
@@ -264,7 +268,7 @@ class PersistOnFlushTable(PersistenceStrategy):
 
 
 @temporal_sqlalchemy.add_clock(
-    'prop_a', 'prop_b',
+    'prop_a', 'prop_b', 'prop_c', 'prop_d', 'prop_e', 'prop_f',
     temporal_schema=TEMPORAL_SCHEMA,
     activity_cls=Activity,
     allow_persist_on_commit=True)

--- a/tests/test_persist_changes_on_commit.py
+++ b/tests/test_persist_changes_on_commit.py
@@ -1,0 +1,166 @@
+import pytest
+
+import temporal_sqlalchemy as temporal
+
+from . import shared, models
+
+
+class TestPersistChangesOnCommit(shared.DatabaseTest):
+    @pytest.fixture(autouse=True)
+    def setup_batched_session(self, session):
+        temporal.temporal_session(session, persist_on_commit=True)
+
+    def test_persist_on_commit(self, session):
+        activity = models.Activity(description='Create temp')
+        session.add(activity)
+
+        t = models.PersistOnCommitTable(prop_a=1234, activity=activity)
+        session.add(t)
+        session.flush()
+
+        activity_query = session.query(models.Activity)
+        assert activity_query.count() == 1
+        activity_result = activity_query.first()
+        assert activity_result.description == 'Create temp'
+
+        clock_query = session.query(
+            models.PersistOnCommitTable.temporal_options.clock_table)
+        assert clock_query.count() == 1
+        clock_result = clock_query.first()
+        assert clock_result.activity_id == activity_result.id
+
+        history_query = session.query(
+            models.PersistOnCommitTable.temporal_options.history_models[
+                models.PersistOnCommitTable.prop_a.property])
+        assert history_query.count() == 0
+
+        session.commit()
+
+        assert history_query.count() == 1
+        history_result = history_query.first()
+        assert history_result.prop_a == 1234
+
+    def test_persist_only_last_change_before_flush(self, session):
+        activity = models.Activity(description='Create temp')
+        session.add(activity)
+
+        t = models.PersistOnCommitTable(prop_a=1234, activity=activity)
+        session.add(t)
+
+        t.prop_a = 4567
+
+        session.flush()
+
+        history_query = session.query(
+            models.PersistOnCommitTable.temporal_options.history_models[
+                models.PersistOnCommitTable.prop_a.property])
+        assert history_query.count() == 0
+
+        session.commit()
+
+        assert history_query.count() == 1
+        history_result = history_query.first()
+        assert history_result.prop_a == 4567
+
+    def test_persist_only_last_change_after_flush(self, session):
+        activity = models.Activity(description='Create temp')
+        session.add(activity)
+
+        t = models.PersistOnCommitTable(prop_a=1234, activity=activity)
+        session.add(t)
+        session.flush()
+
+        t.prop_a = 4567
+
+        history_query = session.query(
+            models.PersistOnCommitTable.temporal_options.history_models[
+                models.PersistOnCommitTable.prop_a.property])
+        assert history_query.count() == 0
+
+        session.commit()
+
+        assert history_query.count() == 1
+        history_result = history_query.first()
+        assert history_result.prop_a == 4567
+
+    def test_mixed_models_persist_on_commit_and_regular_persist(self, session):
+        activity = models.Activity(description='Create temp')
+        session.add(activity)
+
+        t1 = models.PersistOnCommitTable(prop_a=1234, activity=activity)
+        session.add(t1)
+        t2 = models.PersistOnFlushTable(prop_a=1234, activity=activity)
+        session.add(t2)
+        session.flush()
+
+        activity_query = session.query(models.Activity)
+        assert activity_query.count() == 1
+        activity_result = activity_query.first()
+        assert activity_result.description == 'Create temp'
+
+        # check persist on commit works
+        clock_query_1 = session.query(
+            models.PersistOnCommitTable.temporal_options.clock_table)
+        assert clock_query_1.count() == 1
+        clock_result_1 = clock_query_1.first()
+        assert clock_result_1.activity_id == activity_result.id
+
+        history_query_1 = session.query(
+            models.PersistOnCommitTable.temporal_options.history_models[
+                models.PersistOnCommitTable.prop_a.property])
+        assert history_query_1.count() == 0
+
+        # check persist on flush works
+        clock_query_2 = session.query(
+            models.PersistOnFlushTable.temporal_options.clock_table)
+        assert clock_query_2.count() == 1
+        clock_result_2 = clock_query_2.first()
+        assert clock_result_2.activity_id == activity_result.id
+
+        history_query_2 = session.query(
+            models.PersistOnFlushTable.temporal_options.history_models[
+                models.PersistOnFlushTable.prop_a.property])
+        assert history_query_2.count() == 1
+        history_result_2 = history_query_2.first()
+        assert history_result_2.prop_a == 1234
+
+        session.commit()
+
+        # check persist on commit works again
+        assert history_query_1.count() == 1
+        history_result_1 = history_query_1.first()
+        assert history_result_1.prop_a == 1234
+
+    def test_persist_multiple_rows(self, session):
+        activity = models.Activity(description='Create temp')
+        session.add(activity)
+
+        t1 = models.PersistOnCommitTable(prop_a=1234, activity=activity)
+        session.add(t1)
+        t2 = models.PersistOnCommitTable(prop_a=5678, activity=activity)
+        session.add(t2)
+        session.flush()
+
+        activity_query = session.query(models.Activity)
+        assert activity_query.count() == 1
+        activity_result = activity_query.first()
+        assert activity_result.description == 'Create temp'
+
+        clock_query = session.query(
+            models.PersistOnCommitTable.temporal_options.clock_table)
+        assert clock_query.count() == 2
+        clock_result = clock_query.first()
+        assert clock_result.activity_id == activity_result.id
+
+        history_query = session.query(
+            models.PersistOnCommitTable.temporal_options.history_models[
+                models.PersistOnCommitTable.prop_a.property])
+        assert history_query.count() == 0
+
+        session.commit()
+
+        assert history_query.count() == 2
+        history_result_1 = history_query.filter_by(entity_id=t1.id).one()
+        assert history_result_1.prop_a == 1234
+        history_result_2 = history_query.filter_by(entity_id=t2.id).one()
+        assert history_result_2.prop_a == 5678

--- a/tests/test_persist_changes_on_commit.py
+++ b/tests/test_persist_changes_on_commit.py
@@ -164,3 +164,41 @@ class TestPersistChangesOnCommit(shared.DatabaseTest):
         assert history_result_1.prop_a == 1234
         history_result_2 = history_query.filter_by(entity_id=t2.id).one()
         assert history_result_2.prop_a == 5678
+
+    def test_persist_when_inside_nested_transaction(self, session):
+        assert session.transaction.nested is False
+        session.begin_nested()
+        assert session.transaction.nested is True
+
+        activity = models.Activity(description='Create temp')
+        session.add(activity)
+
+        t = models.PersistOnCommitTable(prop_a=1234, activity=activity)
+        session.add(t)
+        session.flush()
+
+        activity_query = session.query(models.Activity)
+        assert activity_query.count() == 1
+        activity_result = activity_query.first()
+        assert activity_result.description == 'Create temp'
+
+        clock_query = session.query(
+            models.PersistOnCommitTable.temporal_options.clock_table)
+        assert clock_query.count() == 1
+        clock_result = clock_query.first()
+        assert clock_result.activity_id == activity_result.id
+
+        history_query = session.query(
+            models.PersistOnCommitTable.temporal_options.history_models[
+                models.PersistOnCommitTable.prop_a.property])
+        assert history_query.count() == 0
+
+        assert session.transaction.nested is True
+        session.commit()
+        assert session.transaction.nested is False
+
+        assert history_query.count() == 1
+        history_result = history_query.first()
+        assert history_result.prop_a == 1234
+
+        session.commit()


### PR DESCRIPTION
Currently temporal generates the history for an object's changes during `flush`.  This can have problems when you want to update an object multiple times and you have to flush in between those changes.  Our previous workaround was to generate a separate activity for the additional updates, but this is a problem because an api request's changes aren't all grouped together.  This is problematic for auditing and certain downstream data processing operations.

This PR adds the ability to defer building the history until the final `commit`.  This allows you to update an update multiple times and still keep those changes as part of the same activity.

I decided to implement it as a behavior flag because a lot of existing code relies on the history being generated during each flush.  The implementation keeps a set of objects changed during each flush, which will grow larger until you `commit`.  We might need to have finer grained control over picking the behavior in the future, but for now, I believe this is fine.

The interface until we merge https://github.com/CloverHealth/temporal-sqlalchemy/pull/39 is less than ideal.  You have to surround the first update in the `clock_tick` context manager, but the following ones cannot be.  This is obviously confusing, but once we merge the other PR, it should work seamlessly.