### PR TITLE
remove behavior flag for persist_on_commit

### DIFF
--- a/tests/test_persist_changes_on_commit.py
+++ b/tests/test_persist_changes_on_commit.py
@@ -6,10 +6,6 @@ from . import shared, models
 
 
 class TestPersistChangesOnCommit(shared.DatabaseTest):
-    @pytest.fixture(autouse=True)
-    def setup_batched_session(self, session):
-        temporal.temporal_session(session, persist_on_commit=True)
-
     def test_persist_on_commit(self, session):
         activity = models.Activity(description='Create temp')
         session.add(activity)
@@ -369,7 +365,7 @@ class TestPersistChangesOnCommit(shared.DatabaseTest):
         assert history_results[0].vclock == NumericRange(empty=True)
 
     def test_persist_on_commit_with_edit_no_clock_tick_with_strict_mode(self, session):
-        temporal.temporal_session(session, persist_on_commit=True, strict_mode=True)
+        temporal.temporal_session(session, strict_mode=True)
 
         create_activity = models.Activity(description='Create temp')
         session.add(create_activity)


### PR DESCRIPTION
I originally wanted to be conservative about the `persist_on_commit` behavior flag, but in reality, you end up having to turn it on in many places to ensure things don't break.  Since we already have an opt-in flag for each model, having the second one isn't adding much.  If you forget to turn it on, it's not obvious what is happening, so I think this behavior flag needs to go.

Second feature change is to start a new changeset whenever a new transaction is started.  This is necessary for nested transactions and should prevent objects from accidentally getting touched by other sessions.