### PR TITLE
remove 3.3 support because python does not support it

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ matrix:
         - '3.6'
         - '3.5'
         - '3.4'
-        - '3.3'
       addons:
         postgresql: 9.5
       env: PG=9.5
@@ -20,7 +19,6 @@ matrix:
         - '3.6'
         - '3.5'
         - '3.4'
-        - '3.3'
       addons:
         postgresql: 9.4
       env: PG=9.4
@@ -28,7 +26,6 @@ matrix:
         - '3.6'
         - '3.5'
         - '3.4'
-        - '3.3'
       addons:
         postgresql: 9.3
       env: PG=9.3

--- a/INSTALL.txt
+++ b/INSTALL.txt
@@ -1,6 +1,6 @@
 Thanks for downloading temporal-sqlalchemy.
 
-To install it, make sure you have Python 3.3 or greater installed. Then run
+To install it, make sure you have Python 3.4 or greater installed. Then run
 this command from the command prompt:
 
     python3 setup.py install

--- a/README.rst
+++ b/README.rst
@@ -57,12 +57,11 @@ this repo run:
 
     # Install all the Python versions this package supports. This will take some
     # time.
-    pyenv install 3.3.6
     pyenv install 3.4.6
     pyenv install 3.5.3
     pyenv install 3.6.3
 
-    pyenv local 3.6.3 3.5.3 3.4.6 3.3.6
+    pyenv local 3.6.3 3.5.3 3.4.6
 
     # Install the development dependencies
     pip3 install -Ur dev-requirements.txt

--- a/circle.yml
+++ b/circle.yml
@@ -5,7 +5,7 @@ machine:
 dependencies:
   override:
     - pip3 install -q -r dev-requirements.txt
-    - pyenv local 3.6.2 3.5.3 3.4.4 3.3.6
+    - pyenv local 3.6.2 3.5.3 3.4.4
 
 test:
   override:

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,6 @@ CLASSIFIERS = [
     'License :: OSI Approved :: BSD License',
     'Operating System :: OS Independent',
     'Programming Language :: Python :: 3 :: Only',
-    'Programming Language :: Python :: 3.3',
     'Programming Language :: Python :: 3.4',
     'Programming Language :: Python :: 3.5',
     'Programming Language :: Python :: 3.6',
@@ -41,7 +40,7 @@ setuptools.setup(
     platforms=['any'],
     keywords='sqlalchemy postgresql orm temporal',
     classifiers=CLASSIFIERS,
-    python_requires='>=3.3',
+    python_requires='>=3.4',
     install_requires=[
         'psycopg2>=2.6.2',
         'singledispatch>=3.4.0.0;python_version<"3.4"',

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py33,py34,py35,py36
+envlist = py34,py35,py36
 usedevelop = true
 passenv = *
 


### PR DESCRIPTION
pytest has dropped support for python 3.3 because python 3.3 is no longer supported https://www.python.org/dev/peps/pep-0398/#x-end-of-life

