### PR TITLE
Use changeset stack

### DIFF
--- a/temporal_sqlalchemy/bases.py
+++ b/temporal_sqlalchemy/bases.py
@@ -13,7 +13,7 @@ import sqlalchemy.orm.attributes as attributes
 import psycopg2.extras as psql_extras
 
 from temporal_sqlalchemy import nine
-from temporal_sqlalchemy.metadata import get_session_metadata
+from temporal_sqlalchemy.metadata import STRICT_MODE_KEY
 
 _ClockSet = collections.namedtuple('_ClockSet', ('effective', 'vclock'))
 
@@ -96,7 +96,7 @@ class TemporalOption(object):
         """record all history for a given clocked object"""
         new_tick = self._get_new_tick(clocked)
 
-        is_strict_mode = get_session_metadata(session).get('strict_mode', False)
+        is_strict_mode = session.info[STRICT_MODE_KEY]
         vclock_history = attributes.get_history(clocked, 'vclock')
         is_vclock_unchanged = vclock_history.unchanged and new_tick == vclock_history.unchanged[0]
 

--- a/temporal_sqlalchemy/metadata.py
+++ b/temporal_sqlalchemy/metadata.py
@@ -1,29 +1,14 @@
 import sqlalchemy.orm as orm
 
-TEMPORAL_METADATA_KEY = '__temporal'
-
 __all__ = [
-    'get_session_metadata',
-    'set_session_metadata',
+    'STRICT_MODE_KEY',
+    'CHANGESET_STACK_KEY',
+    'IS_COMMITTING_KEY',
+    'IS_VCLOCK_UNCHANGED_KEY',
 ]
 
 
-def set_session_metadata(session: orm.Session, metadata: dict):
-    if isinstance(session, orm.Session):
-        session.info[TEMPORAL_METADATA_KEY] = metadata
-    elif isinstance(session, orm.sessionmaker):
-        session.configure(info={TEMPORAL_METADATA_KEY: metadata})
-    else:
-        raise ValueError('Invalid session')
-
-
-def get_session_metadata(session: orm.Session) -> dict:
-    """
-    :return: metadata dictionary, or None if it was never installed
-    """
-    if isinstance(session, orm.Session):
-        return session.info.get(TEMPORAL_METADATA_KEY)
-    elif isinstance(session, orm.sessionmaker):
-        return session.kw.get('info', {}).get(TEMPORAL_METADATA_KEY)
-    else:
-        raise ValueError('Invalid session')
+STRICT_MODE_KEY = '__temporal_strict_mode'
+CHANGESET_STACK_KEY = '__temporal_changeset_stack'
+IS_COMMITTING_KEY = '__temporal_is_committing'
+IS_VCLOCK_UNCHANGED_KEY = '__temporal_is_vclock_unchanged'

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -124,7 +124,7 @@ def _initialize_metadata(session):
     # backfill any missing stack entries
     if len(session.info[CHANGESET_STACK_KEY]) == 0:
         depth = _get_transaction_stack_depth(session.transaction)
-        for i in range(depth):
+        for _ in range(depth):
             session.info[CHANGESET_STACK_KEY].append({})
 
 

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -16,7 +16,10 @@ from temporal_sqlalchemy.metadata import (
 
 
 def get_current_changeset(session):
-    return session.info[CHANGESET_STACK_KEY][-1]
+    stack = session.info[CHANGESET_STACK_KEY]
+    assert len(stack) > 0
+
+    return stack[-1]
 
 
 def _temporal_models(session: orm.Session) -> typing.Iterable[Clocked]:

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -1,5 +1,6 @@
 import datetime
 import itertools
+import random
 import typing
 import warnings
 
@@ -13,13 +14,13 @@ from temporal_sqlalchemy.metadata import (
 )
 
 
-CHANGESET_STACK = 'changeset_stack'
-IS_COMMITTING = 'is_committing'
-IS_VCLOCK_UNCHANGED = 'is_vclock_unchanged'
+CHANGESET_STACK = '__temporal_changeset_stack'
+IS_COMMITTING = '__temporal_is_committing'
+IS_VCLOCK_UNCHANGED = '__temporal_is_vclock_unchanged'
 
 
-def get_current_changeset(metadata):
-    return metadata[CHANGESET_STACK][-1]
+def get_current_changeset(session):
+    return session.info[CHANGESET_STACK][-1]
 
 
 def _temporal_models(session: orm.Session) -> typing.Iterable[Clocked]:
@@ -29,13 +30,14 @@ def _temporal_models(session: orm.Session) -> typing.Iterable[Clocked]:
 
 
 def _build_history(session, correlate_timestamp):
-    metadata = get_session_metadata(session)
-    changeset = get_current_changeset(metadata)
+    changeset = get_current_changeset(session)
     items = list(changeset.items())
     changeset.clear()
 
+    metadata = get_session_metadata(session)
     is_strict_mode = metadata.get('strict_mode', False)
-    is_vclock_unchanged = metadata.get(IS_VCLOCK_UNCHANGED, False)
+
+    is_vclock_unchanged = session.info.get(IS_VCLOCK_UNCHANGED, False)
     if items and is_strict_mode:
         assert not is_vclock_unchanged, \
             'commit() has triggered for a changed temporalized property without a clock tick'
@@ -48,11 +50,13 @@ def persist_history(session: orm.Session, flush_context, instances):
     if any(_temporal_models(session.deleted)):
         raise ValueError("Cannot delete temporal objects.")
 
+    # its possible the temporal session was initialized after the transaction has started
+    _initialize_metadata(session)
+
     correlate_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
     changed_rows = _temporal_models(itertools.chain(session.dirty, session.new))
 
-    metadata = get_session_metadata(session)
-    changeset = get_current_changeset(metadata)
+    changeset = get_current_changeset(session)
     for obj in changed_rows:
         if obj.temporal_options.allow_persist_on_commit:
             new_changes, is_vclock_unchanged = obj.temporal_options.get_history(obj)
@@ -64,69 +68,89 @@ def persist_history(session: orm.Session, flush_context, instances):
                 old_changes = changeset[obj]
                 old_changes.update(new_changes)
 
-            metadata[IS_VCLOCK_UNCHANGED] = metadata[IS_VCLOCK_UNCHANGED] and is_vclock_unchanged
+            session.info[IS_VCLOCK_UNCHANGED] = session.info[IS_VCLOCK_UNCHANGED] and is_vclock_unchanged
         else:
             obj.temporal_options.record_history(obj, session, correlate_timestamp)
 
     # if this is the last flush, build all the history
-    if metadata[IS_COMMITTING]:
+    if session.info[IS_COMMITTING]:
         _build_history(session, correlate_timestamp)
 
-        metadata[IS_COMMITTING] = False
+        session.info[IS_COMMITTING] = False
 
 
 def enable_is_committing_flag(session):
-    metadata = get_session_metadata(session)
+    """before_commit happens before before_flush, and we need to make sure the history gets built
+    during the final one of these two events, so we need to use the gross IS_COMMITTING flag to
+    control this behavior"""
+    session.info[IS_COMMITTING] = True
 
-    metadata[IS_COMMITTING] = True
-
+    # if the session is clean, a final flush won't happen, so try to build the history now
     if session._is_clean():
         correlate_timestamp = datetime.datetime.now(tz=datetime.timezone.utc)
         _build_history(session, correlate_timestamp)
 
     # building the history can cause the session to be dirtied, which will in turn call another
     # flush(), so we want to check this before reseting
+    # if there are more changes, flush will build them itself
     if session._is_clean():
-        metadata[IS_COMMITTING] = False
+        session.info[IS_COMMITTING] = False
+
+
+def _get_transaction_stack_depth(transaction):
+    depth = 0
+
+    current = transaction
+    while current:
+        depth += 1
+        current = transaction.parent
+
+    return depth
+
+
+ARGH = {}
+
+
+def _initialize_metadata(session):
+    if CHANGESET_STACK not in session.info:
+        session.info[CHANGESET_STACK] = []
+
+    if IS_COMMITTING not in session.info:
+        session.info[IS_COMMITTING] = False
+
+    if IS_VCLOCK_UNCHANGED not in session.info:
+        session.info[IS_VCLOCK_UNCHANGED] = True
+
+    # sometimes temporalize a session after a transaction has already been open, so we need to
+    # backfill any missing stack entries
+    if len(session.info[CHANGESET_STACK]) == 0:
+        depth = _get_transaction_stack_depth(session.transaction)
+        for i in range(depth):
+            session.info[CHANGESET_STACK].append({})
 
 
 def start_transaction(session, transaction):
-    metadata = get_session_metadata(session)
+    _initialize_metadata(session)
 
-    metadata[CHANGESET_STACK].append({})
+    session.info[CHANGESET_STACK].append({})
+
+    if len(session.info[CHANGESET_STACK]) > 2:
+        pass #import pdb; pdb.set_trace()
 
 
 def end_transaction(session, transaction):
-    metadata = get_session_metadata(session)
+    # wrap in if statement for cases when the session is temporalized after a transaction has
+    # started, and then there are no actual temporal changes
+    if len(session.info[CHANGESET_STACK]):
+        session.info[CHANGESET_STACK].pop()
 
-    metadata[CHANGESET_STACK].pop()
-
-    # clear out bookkeeping fields if we're ending a top most transaction
+    # reset bookkeeping fields if we're ending a top most transaction
     if transaction.parent is None:
-        metadata[IS_VCLOCK_UNCHANGED] = True
+        session.info[IS_VCLOCK_UNCHANGED] = True
+        session.info[IS_COMMITTING] = False
 
-        if metadata[IS_COMMITTING]:
-            warnings.warn('IS_COMMITTING is still set to True, something is mismatched with temporal session lifecycle events')
-
-
-def _initialize_metadata(session, strict_mode):
-    # sqlalchemy does some weird memoizing / localizing the info dict to each session, so we have
-    # to copy the dictionary if we're just updating it. We now have additional metadata beyond
-    # strict_mode that can't be destroyed between function calls.
-    old_metadata = get_session_metadata(session)
-    temporal_metadata = old_metadata.copy() if old_metadata else {}
-    temporal_metadata['strict_mode'] = strict_mode
-
-    if CHANGESET_STACK not in temporal_metadata:
-        temporal_metadata[CHANGESET_STACK] = []
-
-    if IS_COMMITTING not in temporal_metadata:
-        temporal_metadata[IS_COMMITTING] = False
-
-    if IS_VCLOCK_UNCHANGED not in temporal_metadata:
-        temporal_metadata[IS_VCLOCK_UNCHANGED] = True
-
-    return temporal_metadata
+        # there should be no more changeset stacks at this point, otherwise there is a mismatch
+        assert len(session.info[CHANGESET_STACK]) == 0
 
 
 def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker], strict_mode=False) -> orm.Session:
@@ -137,7 +161,9 @@ def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker], stric
     :param strict_mode: if True, will raise exceptions when improper flush() calls are made (default is False)
     :return: temporalized SQLALchemy ORM session
     """
-    temporal_metadata = _initialize_metadata(session, strict_mode)
+    temporal_metadata = {
+        'strict_mode': strict_mode
+    }
 
     # defer listening to the flush hook until after we update the metadata
     install_flush_hook = not is_temporal_session(session)

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -9,18 +9,15 @@ import sqlalchemy.orm as orm
 
 from temporal_sqlalchemy.bases import TemporalOption, Clocked
 from temporal_sqlalchemy.metadata import (
-    get_session_metadata,
-    set_session_metadata
+    STRICT_MODE_KEY,
+    CHANGESET_STACK_KEY,
+    IS_COMMITTING_KEY,
+    IS_VCLOCK_UNCHANGED_KEY,
 )
 
 
-CHANGESET_STACK = '__temporal_changeset_stack'
-IS_COMMITTING = '__temporal_is_committing'
-IS_VCLOCK_UNCHANGED = '__temporal_is_vclock_unchanged'
-
-
 def get_current_changeset(session):
-    return session.info[CHANGESET_STACK][-1]
+    return session.info[CHANGESET_STACK_KEY][-1]
 
 
 def _temporal_models(session: orm.Session) -> typing.Iterable[Clocked]:
@@ -34,10 +31,8 @@ def _build_history(session, correlate_timestamp):
     items = list(changeset.items())
     changeset.clear()
 
-    metadata = get_session_metadata(session)
-    is_strict_mode = metadata.get('strict_mode', False)
-
-    is_vclock_unchanged = session.info.get(IS_VCLOCK_UNCHANGED, False)
+    is_strict_mode = session.info[STRICT_MODE_KEY]
+    is_vclock_unchanged = session.info[IS_VCLOCK_UNCHANGED_KEY]
     if items and is_strict_mode:
         assert not is_vclock_unchanged, \
             'commit() has triggered for a changed temporalized property without a clock tick'
@@ -68,22 +63,22 @@ def persist_history(session: orm.Session, flush_context, instances):
                 old_changes = changeset[obj]
                 old_changes.update(new_changes)
 
-            session.info[IS_VCLOCK_UNCHANGED] = session.info[IS_VCLOCK_UNCHANGED] and is_vclock_unchanged
+            session.info[IS_VCLOCK_UNCHANGED_KEY] = session.info[IS_VCLOCK_UNCHANGED_KEY] and is_vclock_unchanged
         else:
             obj.temporal_options.record_history(obj, session, correlate_timestamp)
 
     # if this is the last flush, build all the history
-    if session.info[IS_COMMITTING]:
+    if session.info[IS_COMMITTING_KEY]:
         _build_history(session, correlate_timestamp)
 
-        session.info[IS_COMMITTING] = False
+        session.info[IS_COMMITTING_KEY] = False
 
 
 def enable_is_committing_flag(session):
     """before_commit happens before before_flush, and we need to make sure the history gets built
-    during the final one of these two events, so we need to use the gross IS_COMMITTING flag to
+    during the final one of these two events, so we need to use the gross IS_COMMITTING_KEY flag to
     control this behavior"""
-    session.info[IS_COMMITTING] = True
+    session.info[IS_COMMITTING_KEY] = True
 
     # if the session is clean, a final flush won't happen, so try to build the history now
     if session._is_clean():
@@ -94,7 +89,7 @@ def enable_is_committing_flag(session):
     # flush(), so we want to check this before reseting
     # if there are more changes, flush will build them itself
     if session._is_clean():
-        session.info[IS_COMMITTING] = False
+        session.info[IS_COMMITTING_KEY] = False
 
 
 def _get_transaction_stack_depth(transaction):
@@ -112,45 +107,45 @@ ARGH = {}
 
 
 def _initialize_metadata(session):
-    if CHANGESET_STACK not in session.info:
-        session.info[CHANGESET_STACK] = []
+    if CHANGESET_STACK_KEY not in session.info:
+        session.info[CHANGESET_STACK_KEY] = []
 
-    if IS_COMMITTING not in session.info:
-        session.info[IS_COMMITTING] = False
+    if IS_COMMITTING_KEY not in session.info:
+        session.info[IS_COMMITTING_KEY] = False
 
-    if IS_VCLOCK_UNCHANGED not in session.info:
-        session.info[IS_VCLOCK_UNCHANGED] = True
+    if IS_VCLOCK_UNCHANGED_KEY not in session.info:
+        session.info[IS_VCLOCK_UNCHANGED_KEY] = True
 
     # sometimes temporalize a session after a transaction has already been open, so we need to
     # backfill any missing stack entries
-    if len(session.info[CHANGESET_STACK]) == 0:
+    if len(session.info[CHANGESET_STACK_KEY]) == 0:
         depth = _get_transaction_stack_depth(session.transaction)
         for i in range(depth):
-            session.info[CHANGESET_STACK].append({})
+            session.info[CHANGESET_STACK_KEY].append({})
 
 
 def start_transaction(session, transaction):
     _initialize_metadata(session)
 
-    session.info[CHANGESET_STACK].append({})
+    session.info[CHANGESET_STACK_KEY].append({})
 
-    if len(session.info[CHANGESET_STACK]) > 2:
+    if len(session.info[CHANGESET_STACK_KEY]) > 2:
         pass #import pdb; pdb.set_trace()
 
 
 def end_transaction(session, transaction):
     # wrap in if statement for cases when the session is temporalized after a transaction has
     # started, and then there are no actual temporal changes
-    if len(session.info[CHANGESET_STACK]):
-        session.info[CHANGESET_STACK].pop()
+    if len(session.info[CHANGESET_STACK_KEY]):
+        session.info[CHANGESET_STACK_KEY].pop()
 
     # reset bookkeeping fields if we're ending a top most transaction
     if transaction.parent is None:
-        session.info[IS_VCLOCK_UNCHANGED] = True
-        session.info[IS_COMMITTING] = False
+        session.info[IS_VCLOCK_UNCHANGED_KEY] = True
+        session.info[IS_COMMITTING_KEY] = False
 
         # there should be no more changeset stacks at this point, otherwise there is a mismatch
-        assert len(session.info[CHANGESET_STACK]) == 0
+        assert len(session.info[CHANGESET_STACK_KEY]) == 0
 
 
 def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker], strict_mode=False) -> orm.Session:
@@ -161,15 +156,15 @@ def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker], stric
     :param strict_mode: if True, will raise exceptions when improper flush() calls are made (default is False)
     :return: temporalized SQLALchemy ORM session
     """
-    temporal_metadata = {
-        'strict_mode': strict_mode
-    }
-
     # defer listening to the flush hook until after we update the metadata
     install_flush_hook = not is_temporal_session(session)
 
-    # update to the latest metadata
-    set_session_metadata(session, temporal_metadata)
+    if isinstance(session, orm.Session):
+        session.info[STRICT_MODE_KEY] = strict_mode
+    elif isinstance(session, orm.sessionmaker):
+        session.configure(info={STRICT_MODE_KEY: strict_mode})
+    else:
+        raise ValueError('Invalid session')
 
     if install_flush_hook:
         event.listen(session, 'before_flush', persist_history)
@@ -183,4 +178,4 @@ def temporal_session(session: typing.Union[orm.Session, orm.sessionmaker], stric
 
 
 def is_temporal_session(session: orm.Session) -> bool:
-    return isinstance(session, orm.Session) and get_session_metadata(session) is not None
+    return isinstance(session, orm.Session) and session.info.get(STRICT_MODE_KEY) is not None

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -1,6 +1,7 @@
 import datetime
 import itertools
 import typing
+import warnings
 
 import sqlalchemy.event as event
 import sqlalchemy.orm as orm
@@ -25,6 +26,11 @@ def _temporal_models(session: orm.Session) -> typing.Iterable[Clocked]:
 
 
 def _build_history(session, correlate_timestamp):
+    # this shouldn't happen, but it might happen, log a warning and investigate
+    if not session.info.get(CHANGESET_STACK_KEY):
+        warnings.warn('changeset_stack is missing but we are in _build_history()')
+        return
+
     changeset = get_current_changeset(session)
     items = list(changeset.items())
     changeset.clear()

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -1,8 +1,6 @@
 import datetime
 import itertools
-import random
 import typing
-import warnings
 
 import sqlalchemy.event as event
 import sqlalchemy.orm as orm

--- a/temporal_sqlalchemy/session.py
+++ b/temporal_sqlalchemy/session.py
@@ -103,9 +103,6 @@ def _get_transaction_stack_depth(transaction):
     return depth
 
 
-ARGH = {}
-
-
 def _initialize_metadata(session):
     if CHANGESET_STACK_KEY not in session.info:
         session.info[CHANGESET_STACK_KEY] = []
@@ -129,15 +126,13 @@ def start_transaction(session, transaction):
 
     session.info[CHANGESET_STACK_KEY].append({})
 
-    if len(session.info[CHANGESET_STACK_KEY]) > 2:
-        pass #import pdb; pdb.set_trace()
-
 
 def end_transaction(session, transaction):
-    # wrap in if statement for cases when the session is temporalized after a transaction has
-    # started, and then there are no actual temporal changes
-    if len(session.info[CHANGESET_STACK_KEY]):
-        session.info[CHANGESET_STACK_KEY].pop()
+    # there are some edge cases where no temporal changes actually happen, so don't bother
+    if not session.info.get(CHANGESET_STACK_KEY):
+        return
+
+    session.info[CHANGESET_STACK_KEY].pop()
 
     # reset bookkeeping fields if we're ending a top most transaction
     if transaction.parent is None:

--- a/tests/models.py
+++ b/tests/models.py
@@ -275,3 +275,10 @@ class PersistOnFlushTable(PersistenceStrategy):
 class PersistOnCommitTable(PersistenceStrategy):
     __tablename__ = 'persist_on_commit_table'
     __table_args__ = {'schema': SCHEMA}
+
+
+class NonTemporalTable(Base):
+    __tablename__ = 'non_temporal_table'
+    __table_args__ = {'schema': SCHEMA}
+
+    id = auto_uuid()

--- a/tests/test_persist_changes_on_commit.py
+++ b/tests/test_persist_changes_on_commit.py
@@ -69,6 +69,15 @@ class TestPersistChangesOnCommit(shared.DatabaseTest):
         """temporalize after transaction has started to cover some additional edge cases"""
         temporal.temporal_session(non_temporal_session)
 
+    def test_persist_no_temporal_changes(self, non_temporal_session):
+        """temporalize after transaction has started to cover some additional edge cases"""
+        session = temporal.temporal_session(non_temporal_session)
+
+        t = models.NonTemporalTable()
+        session.add(t)
+
+        session.commit()
+
     def test_no_session_cross_pollution(self, session, second_session):
         """make sure the junk from one session doesn't cross pollute another session"""
         activity_1 = models.Activity(description='Create temp')


### PR DESCRIPTION
There were some unfortunate issues with my recent addition of the `persist_on_commit` behavior.

- Multiple open sessions were cross-polluting each other by reusing the nested metadata dict that was being stored in `session.info`.  I refactored this behavior to stop this from happening by removing the nested dict inside session.info and storing everything directly inside `session.info` since sqlalchemy special cases this property (it copies it each time a new session is created).
- Previously, nested transactions with rollbacks were not being handled correctly.  I added a stack to track the changesets to make sure each transactions changes are handled during their respective commits.  Sqlalchemy guarantees there is a 1:1 between `after_transaction_create` and `after_transaction_end`, so there should not be a mismatch.